### PR TITLE
Improve media handling and drag-and-drop playlist

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,3 +85,9 @@ ipcMain.on('display:pause', () => {
 ipcMain.on('display:play', () => {
   if (displayWin) displayWin.webContents.send('display:play');
 });
+ipcMain.on('display:ended', () => {
+  if (controlWin) controlWin.webContents.send('display:ended');
+});
+ipcMain.on('display:error', (_evt, payload) => {
+  if (controlWin) controlWin.webContents.send('display:error', payload);
+});

--- a/preload.js
+++ b/preload.js
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import { pathToFileURL } from 'url';
 
 contextBridge.exposeInMainWorld('presenterAPI', {
   pickMedia: () => ipcRenderer.invoke('pick-media'),
@@ -7,5 +8,14 @@ contextBridge.exposeInMainWorld('presenterAPI', {
   unblack: () => ipcRenderer.send('display:unblack'),
   pause: () => ipcRenderer.send('display:pause'),
   play: () => ipcRenderer.send('display:play'),
-  onProgramEvent: (channel, cb) => ipcRenderer.on(channel, (_e, data) => cb(data))
+  send: (channel, payload) => ipcRenderer.send(channel, payload),
+  onProgramEvent: (channel, cb) => ipcRenderer.on(channel, (_e, data) => cb(data)),
+  toFileURL: (absPath) => {
+    try {
+      return pathToFileURL(absPath).href;
+    } catch (err) {
+      console.error('Failed to convert path to file URL', err);
+      return absPath;
+    }
+  }
 });

--- a/ui/control.html
+++ b/ui/control.html
@@ -28,6 +28,8 @@
     </section>
   </main>
 
+  <div id="status" class="status" role="status" aria-live="polite"></div>
+
   <script src="control.js" type="module"></script>
 </body>
 </html>

--- a/ui/control.js
+++ b/ui/control.js
@@ -7,16 +7,35 @@ const btnBlack = document.getElementById('btnBlack');
 const btnUnblack = document.getElementById('btnUnblack');
 const list = document.getElementById('playlist');
 const previewArea = document.getElementById('previewArea');
+const status = document.getElementById('status');
+const mainEl = document.querySelector('main');
 
-let playlist = [];   // [{ path, type: 'video'|'audio'|'image', name }]
+let playlist = []; // [{ path, type: 'video'|'audio'|'image', name }]
 let index = -1;
+
+function setStatus(message, isError = false) {
+  if (!status) return;
+  status.textContent = message || '';
+  status.classList.toggle('error', Boolean(isError));
+  if (message) {
+    const logger = isError ? console.error : console.log;
+    logger(`[status] ${message}`);
+  }
+}
 
 function classify(filePath) {
   const ext = filePath.split('.').pop().toLowerCase();
-  if (['mp4','mov','webm'].includes(ext)) return 'video';
-  if (['mp3','wav','m4a'].includes(ext)) return 'audio';
-  if (['jpg','jpeg','png'].includes(ext)) return 'image';
+  if (['mp4', 'mov', 'webm'].includes(ext)) return 'video';
+  if (['mp3', 'wav', 'm4a'].includes(ext)) return 'audio';
+  if (['jpg', 'jpeg', 'png'].includes(ext)) return 'image';
   return 'unknown';
+}
+
+function buildItem(filePath) {
+  const type = classify(filePath);
+  if (type === 'unknown') return null;
+  const name = filePath.split(/[\\/]/).pop() || filePath;
+  return { path: filePath, type, name };
 }
 
 function renderList() {
@@ -24,54 +43,137 @@ function renderList() {
   playlist.forEach((item, i) => {
     const li = document.createElement('li');
     li.textContent = `${i === index ? '▶ ' : ''}${item.name}`;
-    li.onclick = () => { index = i; cue(index); };
+    li.addEventListener('click', () => {
+      index = i;
+      cue(index);
+    });
+    li.addEventListener('dblclick', () => {
+      index = i;
+      cue(index);
+      play();
+    });
     list.appendChild(li);
   });
+}
+
+function addPreviewElement(el, item) {
+  el.addEventListener('error', () => {
+    setStatus(`Failed to preview ${item.name}`, true);
+  });
+  previewArea.innerHTML = '';
+  previewArea.appendChild(el);
 }
 
 function cue(i) {
   const item = playlist[i];
   if (!item) return;
-  // Preview on control screen
-  previewArea.innerHTML = '';
-  if (item.type === 'image') {
-    const img = document.createElement('img');
-    img.src = `file://${item.path}`;
-    previewArea.appendChild(img);
-  } else if (item.type === 'audio') {
-    const a = document.createElement('audio'); a.src = `file://${item.path}`; a.controls = true;
-    previewArea.appendChild(a);
-  } else {
-    const v = document.createElement('video'); v.src = `file://${item.path}`; v.controls = true;
-    previewArea.appendChild(v);
+
+  try {
+    const url = window.presenterAPI.toFileURL(item.path);
+    let element;
+    if (item.type === 'image') {
+      element = new Image();
+      element.src = url;
+    } else if (item.type === 'audio') {
+      element = document.createElement('audio');
+      element.src = url;
+      element.controls = true;
+      element.preload = 'metadata';
+    } else if (item.type === 'video') {
+      element = document.createElement('video');
+      element.src = url;
+      element.controls = true;
+      element.preload = 'metadata';
+      element.playsInline = true;
+      element.addEventListener('loadeddata', () => {
+        try { element.pause(); element.currentTime = 0; } catch (err) { console.warn('Preview pause failed', err); }
+      });
+    }
+
+    if (element) addPreviewElement(element, item);
+    setStatus(`Cued ${item.name}`);
+    window.presenterAPI.showOnProgram({ path: item.path, type: item.type, name: item.name });
+    renderList();
+  } catch (err) {
+    console.error('Cue failed', err);
+    setStatus(`Failed to cue ${item?.name || 'item'}`, true);
   }
-  // Send to Program screen (paused/cued)
-  window.presenterAPI.showOnProgram({ path: item.path, type: item.type });
-  renderList();
 }
 
-function play() { window.presenterAPI.play(); }
-function pause() { window.presenterAPI.pause(); }
-function next() { if (index < playlist.length - 1) { index++; cue(index); play(); } }
-function prev() { if (index > 0) { index--; cue(index); play(); } }
+function ensureCurrent() {
+  if (index === -1 && playlist.length) {
+    index = 0;
+    cue(index);
+  }
+}
 
-btnAdd.onclick = async () => {
-  const files = await window.presenterAPI.pickMedia();
-  const items = files.map(p => ({ path: p, type: classify(p), name: p.split(/[\\/]/).pop() }))
-                     .filter(it => it.type !== 'unknown');
+function addPathsToPlaylist(paths) {
+  const items = paths
+    .map(buildItem)
+    .filter(Boolean);
+
+  if (!items.length) {
+    setStatus('No supported media files found.', true);
+    return;
+  }
+
   playlist = playlist.concat(items);
-  if (index === -1 && playlist.length) { index = 0; cue(index); }
+  ensureCurrent();
   renderList();
-};
+  setStatus(`Added ${items.length} item${items.length === 1 ? '' : 's'} to playlist.`);
+}
 
-btnPlay.onclick = play;
-btnPause.onclick = pause;
-btnNext.onclick = next;
-btnPrev.onclick = prev;
-btnBlack.onclick = () => window.presenterAPI.black();
-btnUnblack.onclick = () => window.presenterAPI.unblack();
+function play() {
+  if (index < 0 || !playlist[index]) {
+    setStatus('Nothing cued to play.', true);
+    return;
+  }
+  window.presenterAPI.play();
+}
 
-// Keyboard shortcuts
+function pause() {
+  window.presenterAPI.pause();
+}
+
+function next(auto = false) {
+  if (index < playlist.length - 1) {
+    index += 1;
+    cue(index);
+    play();
+  } else if (!auto) {
+    setStatus('Reached end of playlist.', true);
+  }
+}
+
+function prev() {
+  if (index > 0) {
+    index -= 1;
+    cue(index);
+    play();
+  }
+}
+
+btnAdd.addEventListener('click', async () => {
+  try {
+    const files = await window.presenterAPI.pickMedia();
+    if (!files || !files.length) {
+      setStatus('No files selected.');
+      return;
+    }
+    addPathsToPlaylist(files);
+  } catch (err) {
+    console.error('Add media failed', err);
+    setStatus('Unable to add media.', true);
+  }
+});
+
+btnPlay.addEventListener('click', () => play());
+btnPause.addEventListener('click', () => pause());
+btnNext.addEventListener('click', () => next());
+btnPrev.addEventListener('click', () => prev());
+btnBlack.addEventListener('click', () => window.presenterAPI.black());
+btnUnblack.addEventListener('click', () => window.presenterAPI.unblack());
+
 window.addEventListener('keydown', (e) => {
   if (e.code === 'Space') { e.preventDefault(); play(); }
   if (e.code === 'ArrowRight') next();
@@ -79,3 +181,39 @@ window.addEventListener('keydown', (e) => {
   if (e.key && e.key.toLowerCase() === 'b') window.presenterAPI.black();
   if (e.key && e.key.toLowerCase() === 'u') window.presenterAPI.unblack();
 });
+
+const droppableAreas = [mainEl, list].filter(Boolean);
+droppableAreas.forEach((el) => {
+  el.addEventListener('dragover', (event) => {
+    event.preventDefault();
+  });
+  el.addEventListener('dragenter', (event) => {
+    event.preventDefault();
+    el.classList.add('droppable');
+  });
+  el.addEventListener('dragleave', () => {
+    el.classList.remove('droppable');
+  });
+  el.addEventListener('drop', (event) => {
+    event.preventDefault();
+    el.classList.remove('droppable');
+    const files = [...event.dataTransfer.files].map((f) => f.path).filter(Boolean);
+    if (!files.length) {
+      setStatus('No files detected from drop.', true);
+      return;
+    }
+    addPathsToPlaylist(files);
+  });
+});
+
+window.presenterAPI.onProgramEvent('display:ended', () => {
+  next(true);
+});
+
+window.presenterAPI.onProgramEvent('display:error', (payload = {}) => {
+  const { message, item } = payload;
+  const label = item?.name ? `: ${item.name}` : '';
+  setStatus(`Program error${label ? label : ''}${message ? ` – ${message}` : ''}`, true);
+});
+
+setStatus('Drop files or use Add Media to build your playlist.');

--- a/ui/display.html
+++ b/ui/display.html
@@ -6,12 +6,13 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="display">
-  <div id="blackout" class="black hidden"></div>
+  <div id="blackout" class="black"></div>
   <div id="stage">
     <img id="img" class="hidden" />
     <video id="video" class="hidden" playsinline></video>
     <audio id="audio" class="hidden"></audio>
   </div>
+  <div id="errorBanner" class="error hidden" role="alert"></div>
   <script src="display.js" type="module"></script>
 </body>
 </html>

--- a/ui/display.js
+++ b/ui/display.js
@@ -2,35 +2,123 @@ const img = document.getElementById('img');
 const video = document.getElementById('video');
 const audio = document.getElementById('audio');
 const blackout = document.getElementById('blackout');
+const errorBanner = document.getElementById('errorBanner');
 
-function hideAll() {
-  img.classList.add('hidden');
-  video.classList.add('hidden');
-  audio.classList.add('hidden');
-  video.pause(); audio.pause();
-}
+let currentItem = null;
 
-function showItem(item) {
-  hideAll();
-  if (item.type === 'image') {
-    img.src = `file://${item.path}`;
-    img.classList.remove('hidden');
-  } else if (item.type === 'audio') {
-    audio.src = `file://${item.path}`;
-    audio.classList.remove('hidden');
-    audio.play().catch(()=>{});
-  } else if (item.type === 'video') {
-    video.src = `file://${item.path}`;
-    video.classList.remove('hidden');
-    video.play().catch(()=>{});
+function fileURL(path) {
+  try {
+    return window.presenterAPI.toFileURL(path);
+  } catch (err) {
+    console.error('Failed to convert path to URL', err);
+    return encodeURI(`file://${path}`);
   }
 }
 
+function hideAll() {
+  [img, video, audio].forEach((el) => {
+    if (!el) return;
+    el.onerror = null;
+    if (el.tagName === 'VIDEO' || el.tagName === 'AUDIO') {
+      try { el.pause(); } catch (err) { console.warn('Pause failed', err); }
+      el.removeAttribute('src');
+      if (typeof el.load === 'function') {
+        try { el.load(); } catch (err) { console.warn('Load reset failed', err); }
+      }
+    }
+    if (el.tagName === 'IMG') {
+      el.removeAttribute('src');
+    }
+    el.classList.add('hidden');
+  });
+}
+
+function clearError() {
+  if (errorBanner) {
+    errorBanner.textContent = '';
+    errorBanner.classList.add('hidden');
+  }
+}
+
+function notifyError(message, err) {
+  console.error(message, err);
+  hideAll();
+  blackout?.classList.remove('hidden');
+  if (errorBanner) {
+    errorBanner.textContent = message;
+    errorBanner.classList.remove('hidden');
+  }
+  window.presenterAPI.send('display:error', { message, item: currentItem });
+}
+
+function showItem(item) {
+  currentItem = item || null;
+  clearError();
+  hideAll();
+
+  if (!item) {
+    blackout?.classList.remove('hidden');
+    return;
+  }
+
+  blackout?.classList.add('hidden');
+
+  const url = fileURL(item.path);
+
+  if (item.type === 'image') {
+    img.onerror = (e) => notifyError('Unable to load image.', e);
+    img.src = url;
+    img.classList.remove('hidden');
+  } else if (item.type === 'audio') {
+    audio.onerror = (e) => notifyError('Unable to load audio.', e);
+    audio.src = url;
+    audio.classList.remove('hidden');
+  } else if (item.type === 'video') {
+    video.onerror = (e) => notifyError('Unable to load video.', e);
+    video.src = url;
+    video.setAttribute('playsinline', '');
+    video.classList.remove('hidden');
+  } else {
+    notifyError('Unsupported media type.', new Error(item.type));
+  }
+}
+
+function pauseMedia() {
+  try { video.pause(); } catch (err) { console.warn('Video pause failed', err); }
+  try { audio.pause(); } catch (err) { console.warn('Audio pause failed', err); }
+}
+
+function tryPlay(el, label) {
+  if (el.classList.contains('hidden')) return;
+  el.play().catch((err) => {
+    notifyError(`Unable to play ${label}.`, err);
+  });
+}
+
+video.addEventListener('ended', () => {
+  window.presenterAPI.send('display:ended');
+});
+
+audio.addEventListener('ended', () => {
+  window.presenterAPI.send('display:ended');
+});
+
 window.presenterAPI.onProgramEvent('display:show-item', (item) => showItem(item));
-window.presenterAPI.onProgramEvent('display:black', () => blackout.classList.remove('hidden'));
-window.presenterAPI.onProgramEvent('display:unblack', () => blackout.classList.add('hidden'));
-window.presenterAPI.onProgramEvent('display:pause', () => { video.pause(); audio.pause(); });
+window.presenterAPI.onProgramEvent('display:black', () => {
+  pauseMedia();
+  blackout?.classList.remove('hidden');
+});
+window.presenterAPI.onProgramEvent('display:unblack', () => {
+  blackout?.classList.add('hidden');
+});
+window.presenterAPI.onProgramEvent('display:pause', () => {
+  pauseMedia();
+});
 window.presenterAPI.onProgramEvent('display:play', () => {
-  if (!video.classList.contains('hidden')) video.play().catch(()=>{});
-  if (!audio.classList.contains('hidden')) audio.play().catch(()=>{});
+  if (!video.classList.contains('hidden')) {
+    tryPlay(video, 'video');
+  }
+  if (!audio.classList.contains('hidden')) {
+    tryPlay(audio, 'audio');
+  }
 });

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -14,3 +14,7 @@ li:hover { text-decoration: underline; }
 .display img, .display video { max-width:100%; max-height:100%; }
 .hidden { display:none; }
 .black { position:fixed; inset:0; background:#000; z-index: 9999; }
+.error { position:fixed; inset:auto 0 0 0; padding:16px; text-align:center; background:rgba(176,0,32,0.85); color:#fff; font-size:20px; z-index: 10000; }
+.status { padding:8px 16px; border-top:1px solid #222; background:#151515; min-height:24px; color:#bbb; font-size:14px; }
+.status.error { color:#ff8080; }
+.droppable { outline: 2px dashed #555; outline-offset: -8px; }


### PR DESCRIPTION
## Summary
- convert media paths to safe file URLs via the preload bridge and forward player events between windows
- enhance the control UI with drag-and-drop ingest, resilient cueing, and inline status feedback
- harden the display player with error overlays, black-screen default, and auto-advance signalling

## Testing
- not run (GUI application)


------
https://chatgpt.com/codex/tasks/task_e_68df15b1547c8324bc7e3053ef426719