### PR TITLE
Fix Add Media button file dialog reliability

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ function createWindows() {
     fullscreen: secondary.id !== primary.id,
     backgroundColor: '#000000',
     webPreferences: {
-      preload: path.join(process.cwd(), 'preload.js'),
+      preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true
     },
     autoHideMenuBar: true,
@@ -38,7 +38,7 @@ function createWindows() {
     height: 800,
     backgroundColor: '#111111',
     webPreferences: {
-      preload: path.join(process.cwd(), 'preload.js'),
+      preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true
     },
     autoHideMenuBar: true,


### PR DESCRIPTION
## Summary
- ensure both windows load the preload script via __dirname so presenterAPI is injected
- add a hidden file input helper in the control UI and reuse addPathsToPlaylist for playlist updates
- update Add Media handling to request files over IPC and fall back to the hidden input on failure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df1b546e888324803aca6ed49b87c5