### PR TITLE
Add push workflow and audio display image support

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,13 +58,16 @@ app.whenReady().then(() => {
 
 app.on('window-all-closed', () => { if (process.platform !== 'darwin') app.quit(); });
 
-ipcMain.handle('pick-media', async () => {
+ipcMain.handle('pick-media', async (_evt, opts = {}) => {
+  const allowImagesOnly = Boolean(opts?.imagesOnly);
+  const filters = allowImagesOnly
+    ? [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png'] }]
+    : [{ name: 'Media', extensions: ['mp4', 'mov', 'webm', 'mp3', 'wav', 'm4a', 'jpg', 'jpeg', 'png'] }];
+
   const { canceled, filePaths } = await dialog.showOpenDialog(controlWin, {
-    title: 'Add media',
+    title: allowImagesOnly ? 'Choose image' : 'Add media',
     properties: ['openFile', 'multiSelections'],
-    filters: [
-      { name: 'Media', extensions: ['mp4','mov','webm','mp3','wav','m4a','jpg','jpeg','png'] }
-    ]
+    filters
   });
   if (canceled) return [];
   return filePaths.filter(p => fs.existsSync(p));

--- a/preload.js
+++ b/preload.js
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { pathToFileURL } from 'url';
 
 contextBridge.exposeInMainWorld('presenterAPI', {
-  pickMedia: () => ipcRenderer.invoke('pick-media'),
+  pickMedia: (opts) => ipcRenderer.invoke('pick-media', opts || {}),
   showOnProgram: (item) => ipcRenderer.send('display:show-item', item),
   black: () => ipcRenderer.send('display:black'),
   unblack: () => ipcRenderer.send('display:unblack'),

--- a/ui/control.html
+++ b/ui/control.html
@@ -13,7 +13,12 @@
 
     <div class="right-panel">
       <section class="card preview-card">
-        <header>Preview</header>
+        <header>
+          Preview
+          <div>
+            <button id="btnPush">Push to Program</button>
+          </div>
+        </header>
         <div class="preview-stage" id="previewArea"></div>
       </section>
 
@@ -21,6 +26,7 @@
         <header>
           Next up
           <div class="nextup-actions">
+            <button id="btnSetImage">Set Display Image</button>
             <button id="btnPlayNext">Play Next Up</button>
             <button id="btnClearNext">Clear</button>
           </div>

--- a/ui/display.js
+++ b/ui/display.js
@@ -61,25 +61,45 @@ function showItem(item) {
     return;
   }
 
-  blackout?.classList.add('hidden');
-
+  let showBlackout = true;
   const url = fileURL(item.path);
 
   if (item.type === 'image') {
     img.onerror = (e) => notifyError('Unable to load image.', e);
     img.src = url;
     img.classList.remove('hidden');
+    showBlackout = false;
   } else if (item.type === 'audio') {
     audio.onerror = (e) => notifyError('Unable to load audio.', e);
     audio.src = url;
     audio.classList.remove('hidden');
+
+    if (item.displayImage) {
+      const displayURL = fileURL(item.displayImage);
+      img.onerror = () => {
+        console.warn('Failed to load display image for audio item. Falling back to black.');
+        img.classList.add('hidden');
+        blackout?.classList.remove('hidden');
+      };
+      img.src = displayURL;
+      img.classList.remove('hidden');
+      showBlackout = false;
+    }
   } else if (item.type === 'video') {
     video.onerror = (e) => notifyError('Unable to load video.', e);
     video.src = url;
     video.setAttribute('playsinline', '');
     video.classList.remove('hidden');
+    showBlackout = false;
   } else {
     notifyError('Unsupported media type.', new Error(item.type));
+    return;
+  }
+
+  if (showBlackout) {
+    blackout?.classList.remove('hidden');
+  } else {
+    blackout?.classList.add('hidden');
   }
 }
 

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -16,6 +16,10 @@ button {
   transition: background 120ms ease, border-color 120ms ease, transform 90ms ease;
 }
 
+#btnSetImage {
+  display: none;
+}
+
 button:hover {
   background: #262626;
   border-color: #3a86ff;
@@ -68,6 +72,13 @@ button:active {
   justify-content: space-between;
 }
 
+.preview-card header > div,
+.nextup-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
 .preview-stage,
 .nextup-stage {
   flex: 1;
@@ -90,10 +101,6 @@ button:active {
   padding: 16px;
 }
 
-.nextup-actions button {
-  margin-left: 8px;
-}
-
 /* Thumbnail grid */
 .thumb-grid {
   display: grid;
@@ -114,6 +121,10 @@ button:active {
 .thumb:hover {
   border-color: #3a86ff;
   transform: translateY(-1px);
+}
+
+.thumb.previewing {
+  border-color: #facc15;
 }
 
 .thumb.selected {


### PR DESCRIPTION
## Summary
- add dedicated Push to Program control and display image button in the control UI
- decouple preview from program playback logic and allow staging audio display images
- show optional still imagery for audio items on the program display and extend the picker for image-only selection

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df23da7e588324ba2d280bc66e2bd8