### PR TITLE
Add centralized logging panel to control UI

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -17,5 +17,18 @@ contextBridge.exposeInMainWorld('presenterAPI', {
     }
   },
   send: (channel, payload) => ipcRenderer.send(channel, payload),
-  onProgramEvent: (channel, cb) => ipcRenderer.on(channel, (_e, data) => cb(data))
+  onProgramEvent: (channel, cb) => ipcRenderer.on(channel, (_e, data) => cb(data)),
+  log: {
+    append: (level, source, msg, data = null) => {
+      ipcRenderer.send('log:append', {
+        ts: Date.now(),
+        level,
+        source,
+        msg,
+        data
+      });
+    },
+    onAppend: (cb) => ipcRenderer.on('log:append', (_e, payload) => cb(payload)),
+    download: () => ipcRenderer.invoke?.('log:download')
+  }
 });

--- a/ui/control.html
+++ b/ui/control.html
@@ -48,6 +48,24 @@
     <button id="btnUnblack">Un-Black</button>
   </footer>
 
+  <section class="card logger-card" id="loggerCard">
+    <header>
+      <div>
+        <strong>Logger</strong>
+        <span id="loggerCount" style="color:#888; margin-left:8px;">0 entries</span>
+      </div>
+      <div class="log-actions">
+        <label style="display:inline-flex; gap:6px; align-items:center;">
+          <input type="checkbox" id="chkAutoscroll" checked /> Autoscroll
+        </label>
+        <button id="btnLogClear">Clear</button>
+        <button id="btnLogDownload">Download</button>
+        <button id="btnLogToggle">Collapse</button>
+      </div>
+    </header>
+    <div class="logger-body" id="loggerBody"></div>
+  </section>
+
   <script src="control.js" type="module"></script>
 </body>
 </html>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -244,3 +244,67 @@ button:active {
   outline: 2px dashed #555;
   outline-offset: -8px;
 }
+
+.logger-card {
+  margin: 12px;
+  height: 220px;
+}
+
+.logger-card.collapsed {
+  height: 44px;
+}
+
+.logger-card.collapsed .logger-body {
+  display: none;
+}
+
+.logger-card header {
+  flex: 0 0 auto;
+}
+
+.logger-card .logger-body {
+  flex: 1;
+  overflow: auto;
+  background: #0a0a0a;
+  font-family: ui-monospace, Consolas, 'SFMono-Regular', monospace;
+  font-size: 12px;
+  padding: 8px;
+}
+
+.log-row {
+  display: grid;
+  grid-template-columns: 110px 85px 80px 1fr;
+  gap: 8px;
+  padding: 3px 0;
+  border-bottom: 1px solid #151515;
+}
+
+.log-time {
+  color: #888;
+}
+
+.log-source {
+  color: #9aa;
+}
+
+.log-msg {
+  color: #ddd;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.log-level-INFO {
+  color: #cfe8ff;
+}
+
+.log-level-WARN {
+  color: #ffe8a6;
+}
+
+.log-level-ERROR {
+  color: #ffb4b4;
+}
+
+.log-actions button {
+  margin-left: 8px;
+}


### PR DESCRIPTION
## Summary
- add a shared logging channel and helper so main-process events flow to the control window
- expose a preload logging API and mirror control/display console output into it
- build a collapsible logger panel in the control UI with buffer management, download, and autoscroll controls

## Testing
- not run (requires Electron GUI)


------
https://chatgpt.com/codex/tasks/task_e_68df3c261e3c83249dc0749c284a3f4d