### PR TITLE
Add startup smoke test log for control window

### DIFF
--- a/main.js
+++ b/main.js
@@ -82,6 +82,17 @@ function createWindows() {
     show: false
   });
   controlWin.loadFile(path.join('ui', 'control.html'));
+  // When control window is ready, send a test log
+  controlWin.webContents.once('did-finish-load', () => {
+    const payload = {
+      ts: Date.now(),
+      level: 'INFO',
+      source: 'MAIN',
+      msg: 'Smoke test: Control window loaded',
+      data: null
+    };
+    controlWin.webContents.send('log:append', payload);
+  });
   controlWin.once('ready-to-show', () => controlWin.show());
 
   displayWin.on('closed', () => { displayWin = null; if (controlWin) controlWin.close(); });

--- a/ui/control.js
+++ b/ui/control.js
@@ -24,6 +24,12 @@ const btnLogToggle = document.getElementById('btnLogToggle');
 const chkAutoscroll = document.getElementById('chkAutoscroll');
 const logAPI = window.presenterAPI?.log;
 
+if (window.presenterAPI?.log?.onAppend) {
+  window.presenterAPI.log.onAppend((payload) => {
+    appendLog(payload);
+  });
+}
+
 const LOG_BUFFER_MAX = 1000;
 const logBuffer = [];
 
@@ -40,7 +46,7 @@ function appendLog(entry) {
   if (!entry || !loggerBody) return;
   const { ts, level, source, msg, data } = entry;
 
-  console.log('appendLog got', level, source, msg, data);
+  console.log('appendLog received:', level, source, msg, data);
 
   const row = document.createElement('div');
   row.className = `log-row log-level-${level}`;
@@ -84,10 +90,6 @@ function appendLog(entry) {
   if (!chkAutoscroll || chkAutoscroll.checked) {
     loggerBody.scrollTop = loggerBody.scrollHeight;
   }
-}
-
-if (logAPI?.onAppend) {
-  logAPI.onAppend((payload) => appendLog(payload));
 }
 
 if (logAPI?.append) {


### PR DESCRIPTION
## Summary
- emit a smoke test log from the main process once the control window finishes loading
- ensure the control renderer subscribes to log append events immediately and logs received payloads for debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df43371b8083249a42c95f18a9d6bf