### PR TITLE
Use CommonJS preload script

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,7 +60,7 @@ function createWindows() {
     fullscreen: secondary.id !== primary.id,
     backgroundColor: '#000000',
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true
     },
     autoHideMenuBar: true,
@@ -75,7 +75,7 @@ function createWindows() {
     height: 800,
     backgroundColor: '#111111',
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true
     },
     autoHideMenuBar: true,

--- a/preload.cjs
+++ b/preload.cjs
@@ -1,0 +1,28 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const { pathToFileURL } = require('url');
+
+contextBridge.exposeInMainWorld('presenterAPI', {
+  pickMedia: (opts) => ipcRenderer.invoke('pick-media', opts || {}),
+  showOnProgram: (item) => ipcRenderer.send('display:show-item', item),
+  play: () => ipcRenderer.send('display:play'),
+  pause: () => ipcRenderer.send('display:pause'),
+  black: () => ipcRenderer.send('display:black'),
+  unblack: () => ipcRenderer.send('display:unblack'),
+  toFileURL: (absPath) => pathToFileURL(absPath).href,
+  send: (channel, payload) => ipcRenderer.send(channel, payload),
+  onProgramEvent: (channel, cb) => ipcRenderer.on(channel, (_e, data) => cb(data)),
+  log: {
+    append: (level, source, msg, data = null) => {
+      ipcRenderer.send('log:append', {
+        ts: Date.now(),
+        level,
+        source,
+        msg,
+        data
+      });
+    },
+    onAppend: (cb) => {
+      ipcRenderer.on('log:append', (_e, payload) => cb(payload));
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a CommonJS preload script that exposes the presenter API
- point the control and display windows at the new preload file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df55b52b308324adf26eac928a6d79