### PR TITLE
Fix preview card sizing and media containment

### DIFF
--- a/ui/control.js
+++ b/ui/control.js
@@ -286,15 +286,18 @@ function renderPreview(item) {
 
   if (item.type === 'image') {
     const img = document.createElement('img');
+    img.className = 'fit preview-media-fit';
     img.src = fileUrl(item.path);
     previewArea.appendChild(img);
   } else if (item.type === 'audio') {
     const audio = document.createElement('audio');
+    audio.className = 'preview-media-fit';
     audio.controls = true;
     audio.src = fileUrl(item.path);
     previewArea.appendChild(audio);
   } else {
     const video = document.createElement('video');
+    video.className = 'fit preview-media-fit';
     video.controls = true;
     video.playsInline = true;
     video.src = fileUrl(item.path);

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -51,6 +51,10 @@ button:active {
   display: grid;
   grid-template-rows: 1fr 0.8fr;
   gap: 16px;
+  min-height: 0;
+}
+.right-panel > .card {
+  min-height: 0;
 }
 
 .card {
@@ -60,6 +64,10 @@ button:active {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+.preview-card {
+  min-height: 0;
 }
 
 .card > header {
@@ -87,11 +95,30 @@ button:active {
   justify-content: center;
   background: #000;
 }
+.preview-stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  background: #000;
+  overflow: hidden;
+  min-height: 0;
+}
 
-.preview-stage img,
-.preview-stage video {
+.preview-stage .fit,
+.preview-media-fit {
   max-width: 100%;
   max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  object-position: center center;
+  display: block;
+}
+.preview-stage video.fit::-webkit-media-controls-enclosure {
+  max-width: 100%;
 }
 
 .nextup-placeholder {


### PR DESCRIPTION
## Summary
- prevent preview/right panel cards from expanding due to intrinsic media sizing
- give the preview stage a fixed aspect-ratio viewport that centers and contains media
- add sizing helper classes to previewed image and video elements so they respect the viewport

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0a7c6a39083248ada3b410565896e