### PR TITLE
Add crossfade transitions for program display media

### DIFF
--- a/ui/display.html
+++ b/ui/display.html
@@ -6,12 +6,25 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="display">
-  <div id="blackout" class="black"></div>
-  <div id="stage">
-    <img id="img" class="hidden" />
-    <video id="video" class="hidden" playsinline></video>
-    <audio id="audio" class="hidden"></audio>
+  <!-- Program stage: two layers for crossfade -->
+  <div id="programStage">
+    <div class="layer" id="layerA">
+      <img id="imgA" class="visual" />
+      <video id="videoA" class="visual" playsinline></video>
+    </div>
+
+    <div class="layer" id="layerB">
+      <img id="imgB" class="visual" />
+      <video id="videoB" class="visual" playsinline></video>
+    </div>
+
+    <!-- Single audio element (no crossfade for audio) -->
+    <audio id="audioEl"></audio>
+
+    <!-- Blackout overlay stays above visuals when needed -->
+    <div id="blackout" class="blackout"></div>
   </div>
+
   <div id="errorBanner" class="error hidden" role="alert"></div>
   <script src="display.js" type="module"></script>
 </body>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -232,7 +232,6 @@ button:active {
 }
 
 /* Display window shared styles */
-.display #stage,
 .control #previewArea {
   width: 100%;
   height: 100%;
@@ -242,10 +241,50 @@ button:active {
   justify-content: center;
 }
 
-.display img,
-.display video {
+#programStage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  overflow: hidden;
+}
+
+#programStage audio {
+  display: none;
+}
+
+.layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  transition: opacity 1000ms ease;
+  z-index: 1;
+}
+
+.layer.visible {
+  opacity: 1;
+}
+
+.visual {
   max-width: 100%;
   max-height: 100%;
+  object-fit: contain;
+  display: none;
+}
+
+.visual.show {
+  display: block;
+}
+
+.blackout {
+  position: absolute;
+  inset: 0;
+  background: #000;
+  opacity: 1;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- introduce dual program layers in the display HTML to support crossfading visuals
- add styles for layered crossfade, contain visuals, and keep blackout overlay above content
- update display logic to swap between layers, manage media playback, and preserve blackout handling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0a967a5608324b2caef38cac35bfa