### PR TITLE
Ensure program stage fills display viewport

### DIFF
--- a/ui/display.html
+++ b/ui/display.html
@@ -7,22 +7,24 @@
 </head>
 <body class="display">
   <!-- Program stage: two layers for crossfade -->
-  <div id="programStage">
-    <div class="layer" id="layerA">
-      <img id="imgA" class="visual" />
-      <video id="videoA" class="visual" playsinline></video>
+  <div id="programRoot">
+    <div id="programStage">
+      <div class="layer" id="layerA">
+        <img id="imgA" class="visual" />
+        <video id="videoA" class="visual" playsinline></video>
+      </div>
+
+      <div class="layer" id="layerB">
+        <img id="imgB" class="visual" />
+        <video id="videoB" class="visual" playsinline></video>
+      </div>
+
+      <!-- Single audio element (no crossfade for audio) -->
+      <audio id="audioEl"></audio>
+
+      <!-- Blackout overlay stays above visuals when needed -->
+      <div id="blackout" class="blackout"></div>
     </div>
-
-    <div class="layer" id="layerB">
-      <img id="imgB" class="visual" />
-      <video id="videoB" class="visual" playsinline></video>
-    </div>
-
-    <!-- Single audio element (no crossfade for audio) -->
-    <audio id="audioEl"></audio>
-
-    <!-- Blackout overlay stays above visuals when needed -->
-    <div id="blackout" class="blackout"></div>
   </div>
 
   <div id="errorBanner" class="error hidden" role="alert"></div>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -377,3 +377,62 @@ button:active {
 .log-actions button {
   margin-left: 8px;
 }
+
+/* Ensure Display window always fills viewport */
+html, body.display {
+  height: 100%;
+  min-height: 100%;
+  margin: 0;
+  background: #000 !important;
+  color: #eee;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* Root container for the Program screen */
+#programRoot {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  background: #000;
+  overflow: hidden;
+}
+
+/* The stage that houses the crossfade layers */
+#programStage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  overflow: hidden;
+}
+
+/* Crossfade layers fill the stage */
+.layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  transition: opacity 1000ms ease;
+}
+
+.layer.visible { opacity: 1; }
+
+/* Visual media fits safely in the stage */
+.visual {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: none;
+}
+.visual.show { display: block; }
+
+/* Blackout overlay on top when needed */
+.blackout {
+  position: absolute;
+  inset: 0;
+  background: #000;
+  opacity: 1;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- wrap the Program stage in a dedicated root container for reliable sizing
- add CSS rules so the Display window, root, and stage always fill the viewport with a black background

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ad9796cc83249ae9e432642532c8