### PR TITLE
Add display image support for audio items

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,6 +184,16 @@ ipcMain.handle('pick-media', async (_evt, opts = {}) => {
   return filePaths.filter(p => fs.existsSync(p));
 });
 
+ipcMain.handle('pick-image', async () => {
+  const result = await dialog.showOpenDialog({
+    properties: ['openFile'],
+    filters: [
+      { name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp'] }
+    ]
+  });
+  return result;
+});
+
 ipcMain.on('display:show-item', (_evt, item) => {
   try {
     console.log('MAIN: forwarding to display', item);

--- a/preload.cjs
+++ b/preload.cjs
@@ -3,6 +3,10 @@ const { pathToFileURL } = require('url');
 
 contextBridge.exposeInMainWorld('presenterAPI', {
   pickMedia: (opts) => ipcRenderer.invoke('pick-media', opts || {}),
+  pickImage: async () => {
+    const { canceled, filePaths } = await ipcRenderer.invoke('pick-image');
+    return canceled ? null : filePaths[0];
+  },
   showOnProgram: (item) => ipcRenderer.send('display:show-item', item),
   play: () => ipcRenderer.send('display:play'),
   pause: () => ipcRenderer.send('display:pause'),


### PR DESCRIPTION
## Summary
- add an Electron IPC handler and preload bridge for picking a single image
- allow audio items to store display images and update thumbnails and preview rendering
- show attached display images on the program display when audio plays

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e0afdacb9083249370fb4bdef6827d