### PR TITLE
Ensure packaged app uses ESM entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
       "preload.js",
       "preload.cjs",
       "ui/**/*",
-      "package.json"
+      "package.json",
+      "ui/**",
+      "dist/**",
+      "dist-electron/**"
     ],
     "asarUnpack": [
       "dist-electron/preload.cjs",
@@ -54,6 +57,11 @@
       "oneClick": true,
       "perMachine": false,
       "allowToChangeInstallationDirectory": false
+    },
+    "asar": true,
+    "extraMetadata": {
+      "main": "main.js",
+      "type": "module"
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure the root package metadata specifies the ESM main entry file
- extend the electron-builder configuration to include the required files, enable ASAR packaging, and mirror the ESM metadata in the packaged app

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0c3fee59083249d13a01cc289cc0e