### PR TITLE
Ensure packaged preload resolves inside app.asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,20 +16,13 @@
     "appId": "nz.bfh.presenter",
     "productName": "BF Presenter",
     "files": [
-      "dist/**/*",
-      "dist-electron/**/*",
+      "dist/**",
+      "dist-electron/**",
       "main.js",
       "preload.js",
       "preload.cjs",
-      "ui/**/*",
-      "package.json",
       "ui/**",
-      "dist/**",
-      "dist-electron/**"
-    ],
-    "asarUnpack": [
-      "dist-electron/preload.cjs",
-      "preload.cjs"
+      "package.json"
     ],
     "directories": {
       "buildResources": "build"


### PR DESCRIPTION
## Summary
- ensure preload.cjs remains packaged by deduplicating the files list and removing asar unpack overrides
- add a preload resolver that looks inside app.asar first with development fallbacks for both BrowserWindows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c658e27c832489df810519efa75c