### PR TITLE
Add background fallback, blank toggle, and transport icon controls

### DIFF
--- a/main.js
+++ b/main.js
@@ -208,13 +208,17 @@ ipcMain.handle('pick-media', async (_evt, opts = {}) => {
 });
 
 ipcMain.handle('pick-image', async () => {
-  const result = await dialog.showOpenDialog({
+  const { canceled, filePaths } = await dialog.showOpenDialog({
     properties: ['openFile'],
-    filters: [
-      { name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp'] }
-    ]
+    filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp'] }]
   });
-  return result;
+  return canceled ? null : filePaths[0];
+});
+
+ipcMain.on('display:set-background', (_evt, absPath) => {
+  if (displayWin && !displayWin.isDestroyed()) {
+    displayWin.webContents.send('display:set-background', absPath || null);
+  }
 });
 
 ipcMain.on('display:show-item', (_evt, item) => {

--- a/preload.cjs
+++ b/preload.cjs
@@ -3,10 +3,8 @@ const { pathToFileURL } = require('url');
 
 contextBridge.exposeInMainWorld('presenterAPI', {
   pickMedia: (opts) => ipcRenderer.invoke('pick-media', opts || {}),
-  pickImage: async () => {
-    const { canceled, filePaths } = await ipcRenderer.invoke('pick-image');
-    return canceled ? null : filePaths[0];
-  },
+  pickImage: () => ipcRenderer.invoke('pick-image'),
+  setBackground: (absPath) => ipcRenderer.send('display:set-background', absPath),
   showOnProgram: (item) => ipcRenderer.send('display:show-item', item),
   play: () => ipcRenderer.send('display:play'),
   pause: () => ipcRenderer.send('display:pause'),

--- a/ui/control.html
+++ b/ui/control.html
@@ -40,12 +40,11 @@
 
   <footer class="toolbar">
     <button id="btnAdd">Add Media</button>
-    <button id="btnPlay">Play</button>
-    <button id="btnPause">Pause</button>
-    <button id="btnPrev">Prev</button>
-    <button id="btnNext">Next</button>
-    <button id="btnBlack">Black</button>
-    <button id="btnUnblack">Un-Black</button>
+    <button id="btnPlay" aria-label="Play" title="Play">▶</button>
+    <button id="btnPrev" aria-label="Previous" title="Previous">⏮</button>
+    <button id="btnNext" aria-label="Next" title="Next">⏭</button>
+    <button id="btnBlankToggle">Blank</button>
+    <button id="btnBackground">Background</button>
   </footer>
 
   <section class="card logger-card" id="loggerCard">


### PR DESCRIPTION
## Summary
- replace the separate blank/unblack buttons with a toggle and add a background picker control
- expose pick-image and background IPC helpers so the control window can request a fallback image
- update the display renderer to honor a persistent background image when the program is idle and not blanked
- convert the transport controls to icon buttons and make the play control toggle between play and pause

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c43caba88324b07f1c5867c7905e