### PR TITLE
Ensure program visuals fit within stage

### DIFF
--- a/ui/display.js
+++ b/ui/display.js
@@ -228,6 +228,8 @@ function notifyError(message, err) {
 }
 
 function fileUrl(p) {
+  if (!p) return '';
+  if (typeof p === 'string' && /^https?:\/\//i.test(p)) return p;
   if (window.presenterAPI?.toFileURL) return window.presenterAPI.toFileURL(p);
   return 'file:///' + String(p).replace(/\\/g, '/').replace(/^\/+/, '');
 }
@@ -297,7 +299,7 @@ function showItem(item) {
     }
 
     if (item.displayImage && incoming?.img) {
-      const imageSrc = item.displayImage.startsWith('http') ? item.displayImage : fileUrl(item.displayImage);
+      const imageSrc = fileUrl(item.displayImage);
       incoming.img.onerror = (e) => notifyError('Unable to load image.', e);
       incoming.img.src = imageSrc;
       incoming.img.classList.add('show');

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -267,10 +267,14 @@ button:active {
   opacity: 1;
 }
 
+/* Program stage visuals always fit and center */
 .visual {
   max-width: 100%;
   max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;
+  object-position: center;
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- ensure program stage visuals always scale to fit and remain centered
- use the shared fileUrl helper when showing display images so they pick up the fit styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1ddfeb288832486d0bae819f23942