### PR TITLE
Fix preview push flow and ignore incomplete display items

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,6 +222,11 @@ ipcMain.on('display:set-background', (_evt, absPath) => {
 });
 
 ipcMain.on('display:show-item', (_evt, item) => {
+  if (!item || !item.path) {
+    console.warn('[MAIN] Ignored display:show-item without path', item);
+    return;
+  }
+
   try {
     console.log('MAIN: forwarding to display', item);
     const forwarded = { ...item };


### PR DESCRIPTION
## Summary
- ignore `display:show-item` IPC messages that do not include a path
- add a shared preview/next-up promotion helper and reuse it for push button and end-of-playback handling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e2f7e25b3c8324b6b8f1694fce92c7