### PR TITLE
Persist display background between sessions

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ app.setPath('userData', path.join(__dirname, 'userdata'));
 
 let controlWin, displayWin;
 let fileServerPort = null;
+let backgroundImagePath = null;
 
 function encodePathForUrl(p) {
   return Buffer.from(p, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
@@ -216,8 +217,15 @@ ipcMain.handle('pick-image', async () => {
 });
 
 ipcMain.on('display:set-background', (_evt, absPath) => {
+  backgroundImagePath = absPath || null;
   if (displayWin && !displayWin.isDestroyed()) {
-    displayWin.webContents.send('display:set-background', absPath || null);
+    displayWin.webContents.send('display:set-background', backgroundImagePath);
+  }
+});
+
+ipcMain.on('display:get-background', (event) => {
+  if (backgroundImagePath) {
+    event.reply('display:set-background', backgroundImagePath);
   }
 });
 

--- a/ui/display.js
+++ b/ui/display.js
@@ -25,6 +25,7 @@ function logDisplay(level, msg, data = null) {
 }
 
 console.log('Display ready');
+window.presenterAPI.send('display:get-background');
 
 (function tapConsole() {
   if (!logAPI?.append) return;
@@ -422,7 +423,9 @@ window.presenterAPI.onProgramEvent('display:unblack', () => {
 
 window.presenterAPI.onProgramEvent('display:set-background', (absPath) => {
   backgroundImagePath = absPath || null;
-  if (!isBlanked && !hasActiveVisual()) {
+  console.log('DISPLAY: background set to', backgroundImagePath || 'none');
+
+  if (!hasActiveVisual() && !isBlanked) {
     showBackgroundFallback();
   }
 });


### PR DESCRIPTION
## Summary
- store the latest background path in the main process and reply to display background requests
- request and persist the display background path in the display renderer so idle fallback uses it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2fd8ef14c8324acea67553d1bb14b