### PR TITLE
Stop clearing background when program queue is empty

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ app.setPath('userData', path.join(__dirname, 'userdata'));
 
 let controlWin, displayWin;
 let fileServerPort = null;
+let backgroundImagePath = null;
 
 function encodePathForUrl(p) {
   return Buffer.from(p, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
@@ -216,8 +217,15 @@ ipcMain.handle('pick-image', async () => {
 });
 
 ipcMain.on('display:set-background', (_evt, absPath) => {
+  backgroundImagePath = absPath || null;
   if (displayWin && !displayWin.isDestroyed()) {
-    displayWin.webContents.send('display:set-background', absPath || null);
+    displayWin.webContents.send('display:set-background', backgroundImagePath);
+  }
+});
+
+ipcMain.on('display:get-background', (event) => {
+  if (backgroundImagePath) {
+    event.reply('display:set-background', backgroundImagePath);
   }
 });
 

--- a/ui/control.js
+++ b/ui/control.js
@@ -660,7 +660,6 @@ window.presenterAPI?.onProgramEvent?.('display:ended', () => {
 
   if (!previewId && !nextUpId) {
     console.log('CONTROL: No Preview or Next Up — show fallback background');
-    window.presenterAPI?.setBackground?.(null);
   }
 });
 

--- a/ui/display.js
+++ b/ui/display.js
@@ -25,6 +25,7 @@ function logDisplay(level, msg, data = null) {
 }
 
 console.log('Display ready');
+window.presenterAPI.send('display:get-background');
 
 (function tapConsole() {
   if (!logAPI?.append) return;
@@ -422,7 +423,9 @@ window.presenterAPI.onProgramEvent('display:unblack', () => {
 
 window.presenterAPI.onProgramEvent('display:set-background', (absPath) => {
   backgroundImagePath = absPath || null;
-  if (!isBlanked && !hasActiveVisual()) {
+  console.log('DISPLAY: background set to', backgroundImagePath || 'none');
+
+  if (!hasActiveVisual() && !isBlanked) {
     showBackgroundFallback();
   }
 });


### PR DESCRIPTION
## Summary
- stop the control window from clearing the display background when playback ends with no queued media

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2fd8ef14c8324acea67553d1bb14b