### PR TITLE
Ensure stage visuals maintain full visibility

### DIFF
--- a/ui/styles.css
+++ b/ui/styles.css
@@ -269,13 +269,12 @@ button:active {
 
 /* Program stage visuals always fit and center */
 .visual {
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   object-position: center;
   display: none;
+  background: #000;
 }
 
 .visual.show {


### PR DESCRIPTION
## Summary
- switch program visual elements to `object-fit: contain` so media stays fully visible on screen
- add a black background to visuals to provide neutral letterboxing when aspect ratios differ

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3033511e88324967233e07fac9613