### PR TITLE
Fit staged media to stage bounds

### DIFF
--- a/ui/control.js
+++ b/ui/control.js
@@ -381,24 +381,24 @@ function renderPreview(item) {
 
   if (item.type === 'image') {
     const img = document.createElement('img');
-    img.className = 'fit preview-media-fit';
+    img.className = 'visual preview-media';
     img.src = fileUrl(item.path);
     previewArea.appendChild(img);
   } else if (item.type === 'audio') {
     if (item.displayImage) {
       const img = document.createElement('img');
-      img.className = 'fit preview-media-fit';
+      img.className = 'visual preview-media';
       img.src = fileUrl(item.displayImage);
       previewArea.appendChild(img);
     }
     const audio = document.createElement('audio');
-    audio.className = 'preview-media-fit';
+    audio.className = 'preview-audio';
     audio.controls = true;
     audio.src = fileUrl(item.path);
     previewArea.appendChild(audio);
   } else {
     const video = document.createElement('video');
-    video.className = 'fit preview-media-fit';
+    video.className = 'visual preview-media';
     video.controls = true;
     video.playsInline = true;
     video.src = fileUrl(item.path);

--- a/ui/display.js
+++ b/ui/display.js
@@ -95,6 +95,17 @@ function getInactiveLayer() {
   return getLayerElements(inactiveKey);
 }
 
+function resetVisualClass(el) {
+  if (!el) return;
+  el.className = 'visual';
+}
+
+function showVisual(el) {
+  if (!el) return;
+  resetVisualClass(el);
+  el.classList.add('show');
+}
+
 function resetSwapTimer() {
   if (swapTimer) {
     clearTimeout(swapTimer);
@@ -114,12 +125,12 @@ function clearLayerContent(layer) {
     try { layer.video.pause(); } catch {}
     layer.video.removeAttribute('src');
     try { layer.video.load(); } catch (err) { console.warn('Video load reset failed', err); }
-    layer.video.classList.remove('show');
+    resetVisualClass(layer.video);
   }
   if (layer.img) {
     layer.img.onerror = null;
     layer.img.removeAttribute('src');
-    layer.img.classList.remove('show');
+    resetVisualClass(layer.img);
   }
 }
 
@@ -149,7 +160,7 @@ function showFallbackAfterEnd(expectedToken) {
 
     if (incoming?.img) {
       incoming.img.src = fileUrl(backgroundImagePath);
-      incoming.img.classList.add('show');
+      showVisual(incoming.img);
     }
     blackout.classList.add('hidden');
     incoming.layer?.classList.add('visible');
@@ -180,7 +191,7 @@ function showBackgroundFallback() {
   if (backgroundImagePath) {
     if (incoming?.img) {
       incoming.img.src = fileUrl(backgroundImagePath);
-      incoming.img.classList.add('show');
+      showVisual(incoming.img);
     }
     blackout?.classList.add('hidden');
     incoming.layer?.classList.add('visible');
@@ -251,7 +262,7 @@ function prepareImage(layer, item) {
   if (!src) return false;
   layer.img.onerror = (e) => notifyError('Unable to load image.', e);
   layer.img.src = src;
-  layer.img.classList.add('show');
+  showVisual(layer.img);
   return true;
 }
 
@@ -263,7 +274,7 @@ function prepareVideo(layer, item) {
   layer.video.src = src;
   layer.video.preload = 'auto';
   layer.video.setAttribute('playsinline', '');
-  layer.video.classList.add('show');
+  showVisual(layer.video);
   return true;
 }
 
@@ -318,7 +329,7 @@ function showItem(item) {
       const imageSrc = fileUrl(item.displayImage);
       incoming.img.onerror = (e) => notifyError('Unable to load image.', e);
       incoming.img.src = imageSrc;
-      incoming.img.classList.add('show');
+      showVisual(incoming.img);
       willShowVisual = true;
       blackout?.classList.add('hidden');
     } else {
@@ -344,7 +355,7 @@ function showItem(item) {
       clearLayerContent(incoming);
       if (incoming?.img) {
         incoming.img.src = fileUrl(backgroundImagePath);
-        incoming.img.classList.add('show');
+        showVisual(incoming.img);
       }
       blackout?.classList.add('hidden');
       incoming.layer?.classList.add('visible');

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -97,28 +97,14 @@ button:active {
 }
 .preview-stage {
   position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 16 / 9;
-  width: 100%;
-  background: #000;
-  overflow: hidden;
   min-height: 0;
-}
-
-.preview-stage .fit,
-.preview-media-fit {
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
-  object-fit: contain;
-  object-position: center center;
-  display: block;
-}
-.preview-stage video.fit::-webkit-media-controls-enclosure {
-  max-width: 100%;
 }
 
 .nextup-placeholder {
@@ -245,8 +231,11 @@ button:active {
   position: relative;
   width: 100%;
   height: 100%;
-  background: #000;
   overflow: hidden;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #programStage audio {
@@ -256,8 +245,13 @@ button:active {
 .layer {
   position: absolute;
   inset: 0;
-  display: grid;
-  place-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   opacity: 0;
   transition: opacity 1000ms ease;
   z-index: 1;
@@ -265,20 +259,6 @@ button:active {
 
 .layer.visible {
   opacity: 1;
-}
-
-/* Program stage visuals always fit and center */
-.visual {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
-  display: none;
-  background: #000;
-}
-
-.visual.show {
-  display: block;
 }
 
 .blackout {
@@ -401,35 +381,60 @@ html, body.display {
   overflow: hidden;
 }
 
-/* The stage that houses the crossfade layers */
-#programStage {
-  position: relative;
+
+/* Applies to all visual media on both Preview and Program screens */
+.visual,
+.preview-media,
+.preview-stage img,
+.preview-stage video {
   width: 100%;
   height: 100%;
-  background: #000;
-  overflow: hidden;
-}
-
-/* Crossfade layers fill the stage */
-.layer {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  opacity: 0;
-  transition: opacity 1000ms ease;
-}
-
-.layer.visible { opacity: 1; }
-
-/* Visual media fits safely in the stage */
-.visual {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  object-position: center;
+  display: block;
+  margin: 0 auto;
+  background: #000;
+}
+
+.visual {
   display: none;
 }
-.visual.show { display: block; }
+
+.visual.show {
+  display: block;
+}
+
+.preview-audio {
+  width: 100%;
+  max-width: 100%;
+  display: block;
+  margin: 0 auto;
+}
+
+/* Containing elements should never shrink below visible area */
+.preview-stage,
+#programStage,
+.layer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.layer {
+  position: absolute;
+  inset: 0;
+  transition: opacity 1000ms ease;
+  z-index: 1;
+}
+
+.layer.visible { opacity: 1; }
 
 /* Blackout overlay on top when needed */
 .blackout {


### PR DESCRIPTION
## Summary
- update preview and program stage containers so visual media always centers and fits without cropping
- ensure display logic resets visuals to the universal class before showing images or videos
- align control preview rendering with the new visual media styling and add audio-specific styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3293061108324a05daf52b23ea5a7