### PR TITLE
Enable thumbnail drag-and-drop between grid and staging areas

### DIFF
--- a/ui/styles.css
+++ b/ui/styles.css
@@ -446,3 +446,8 @@ html, body.display {
   opacity: 1;
   pointer-events: none;
 }
+
+.droptarget {
+  outline: 2px dashed rgba(255, 255, 255, 0.35);
+  outline-offset: -6px;
+}


### PR DESCRIPTION
## Summary
- make grid thumbnails draggable and package their IDs for drag-and-drop
- allow preview and next up panels to accept thumbnail drops or external files
- add a drop target outline highlight for visual feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3386681b483248d411ea2970ea034