### PR TITLE
Enable drag-to-reorder in control media grid

### DIFF
--- a/ui/styles.css
+++ b/ui/styles.css
@@ -153,6 +153,10 @@ button:active {
   box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.55) inset;
 }
 
+.media-thumb {
+  position: relative;
+}
+
 .thumb.readonly {
   cursor: default;
 }
@@ -197,6 +201,26 @@ button:active {
 
 .badge.audio {
   color: #eaa;
+}
+
+.media-thumb.dragging {
+  opacity: 0.5;
+}
+
+.media-thumb.drop-before::before,
+.media-thumb.drop-after::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: #5ac8fa;
+}
+.media-thumb.drop-before::before {
+  left: -2px;
+}
+.media-thumb.drop-after::after {
+  right: -2px;
 }
 
 .badge.image {


### PR DESCRIPTION
## Summary
- add drag state helpers for tracking thumbnail reorders in the control grid
- enable thumbnail drag-and-drop handlers to update media ordering immediately
- provide visual feedback styles for dragging and drop positions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e425cff6ec8324a483d3605a3e41cd