### PR TITLE
Track program element for reliable seeking

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 FFMPEG_PATH=C:\Users\anthony\AppData\Local\Microsoft\WinGet\Packages\Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe\ffmpeg-8.0-full_build\bin\ffmpeg.exe
 
+npm start

--- a/main.js
+++ b/main.js
@@ -284,6 +284,8 @@ ipcMain.on('display:play', () => {
   if (displayWin && !displayWin.isDestroyed()) displayWin.webContents.send('display:play');
 });
 ipcMain.on('display:seek', (_evt, payload) => {
+  // display:seek is forwarded from Control to the Display window here.
+  console.log('[MAIN] forwarding display:seek', payload);
   if (displayWin && !displayWin.isDestroyed()) displayWin.webContents.send('display:seek', payload);
 });
 ipcMain.on('display:ended', () => {

--- a/main.js
+++ b/main.js
@@ -283,9 +283,15 @@ ipcMain.on('display:pause', () => {
 ipcMain.on('display:play', () => {
   if (displayWin && !displayWin.isDestroyed()) displayWin.webContents.send('display:play');
 });
+ipcMain.on('display:seek', (_evt, payload) => {
+  if (displayWin && !displayWin.isDestroyed()) displayWin.webContents.send('display:seek', payload);
+});
 ipcMain.on('display:ended', () => {
   if (controlWin && !controlWin.isDestroyed()) controlWin.webContents.send('display:ended');
   logMain('INFO', 'Display reported playback ended');
+});
+ipcMain.on('display:playback-progress', (_evt, payload) => {
+  if (controlWin && !controlWin.isDestroyed()) controlWin.webContents.send('display:playback-progress', payload);
 });
 ipcMain.on('display:error', (_evt, payload) => {
   if (controlWin && !controlWin.isDestroyed()) controlWin.webContents.send('display:error', payload);

--- a/ui/control.html
+++ b/ui/control.html
@@ -20,6 +20,12 @@
             <button id="btnClearPreview" title="Clear preview">Clear</button>
           </div>
         </header>
+        <div class="program-progress-wrapper">
+          <div class="program-progress-track" id="programProgressTrack">
+            <div class="program-progress-fill" id="programProgressFill"></div>
+            <div class="program-progress-handle" id="programProgressHandle"></div>
+          </div>
+        </div>
         <div class="preview-stage" id="previewArea"></div>
       </section>
 

--- a/ui/control.html
+++ b/ui/control.html
@@ -12,6 +12,21 @@
     </div>
 
     <div class="right-panel">
+      <section class="card program-card">
+        <header>
+          <div class="program-header-left">
+            <strong>Display</strong>
+            <span id="programTimeLabel" class="program-time-label">0:00 / 0:00</span>
+          </div>
+        </header>
+        <div class="program-progress-wrapper">
+          <div class="program-progress-track" id="programProgressTrack">
+            <div class="program-progress-fill" id="programProgressFill"></div>
+            <div class="program-progress-handle" id="programProgressHandle"></div>
+          </div>
+        </div>
+      </section>
+
       <section class="card preview-card">
         <header>
           Preview

--- a/ui/control.html
+++ b/ui/control.html
@@ -16,14 +16,11 @@
         <header>
           <div class="program-header-left">
             <strong>Display</strong>
-            <span id="programTimeLabel" class="program-time-label">0:00 / 0:00</span>
+            <span id="displayTimeLabel" class="program-time-label">0:00 / 0:00</span>
           </div>
         </header>
         <div class="program-progress-wrapper">
-          <div class="program-progress-track" id="programProgressTrack">
-            <div class="program-progress-fill" id="programProgressFill"></div>
-            <div class="program-progress-handle" id="programProgressHandle"></div>
-          </div>
+          <input id="displayScrubber" type="range" min="0" max="100" step="0.1" value="0" />
         </div>
       </section>
 
@@ -35,12 +32,6 @@
             <button id="btnClearPreview" title="Clear preview">Clear</button>
           </div>
         </header>
-        <div class="program-progress-wrapper">
-          <div class="program-progress-track" id="programProgressTrack">
-            <div class="program-progress-fill" id="programProgressFill"></div>
-            <div class="program-progress-handle" id="programProgressHandle"></div>
-          </div>
-        </div>
         <div class="preview-stage" id="previewArea"></div>
       </section>
 

--- a/ui/control.html
+++ b/ui/control.html
@@ -12,6 +12,24 @@
     </div>
 
     <div class="right-panel">
+      <section class="card display-card">
+        <header class="display-header">
+          <span class="display-title">Display</span>
+          <span id="displayTimeLabel" class="display-time">0:00 / 0:00</span>
+        </header>
+        <div class="display-progress-row">
+          <input
+            id="displayScrubber"
+            type="range"
+            min="0"
+            max="100"
+            step="0.1"
+            value="0"
+            class="display-scrubber"
+          />
+        </div>
+      </section>
+
       <section class="card preview-card">
         <header>
           Preview

--- a/ui/control.js
+++ b/ui/control.js
@@ -165,6 +165,8 @@ function setupDisplayScrubber() {
     updateFromPercent();
     isDisplayScrubbing = false;
 
+    // display:seek is sent from this control-side handler.
+    console.log('[CONTROL] display:seek sending time', displayCurrentTime, 'duration', displayDuration);
     window.presenterAPI?.send?.('display:seek', { time: displayCurrentTime });
   });
 }

--- a/ui/control.js
+++ b/ui/control.js
@@ -16,9 +16,8 @@ const previewArea = document.getElementById('previewArea');
 const nextUpArea = document.getElementById('nextUpArea');
 const leftPanel = document.querySelector('.left-panel');
 
-const progressTrack = document.getElementById('programProgressTrack');
-const progressFill = document.getElementById('programProgressFill');
-const progressHandle = document.getElementById('programProgressHandle');
+const displayScrubber = document.getElementById('displayScrubber');
+const displayTimeLabel = document.getElementById('displayTimeLabel');
 
 const loggerBody = document.getElementById('loggerBody');
 const loggerCard = document.getElementById('loggerCard');
@@ -43,9 +42,9 @@ const selectedMediaIds = new Set();
 
 let draggingId = null;
 
-let programDuration = 0;
-let programCurrentTime = 0;
-let isScrubbingProgram = false;
+let displayDuration = 0;
+let displayCurrentTime = 0;
+let isDisplayScrubbing = false;
 
 function indexById(arr, id) {
   return arr.findIndex((m) => m.id === id);
@@ -92,7 +91,8 @@ btnRepeatToggle.onclick = () => {
 
 updatePlayToggleUI(false);
 updateRepeatButton();
-updateProgramProgressUI();
+setupDisplayScrubber();
+updateDisplayUI();
 
 function fileUrl(p) {
   try {
@@ -122,59 +122,50 @@ function tsString(ts) {
   return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}.${ms}`;
 }
 
-function updateProgramProgressUI() {
-  if (!progressTrack || !progressFill || !progressHandle) return;
-  const duration = programDuration > 0 ? programDuration : 0;
-  const current = Math.max(0, Math.min(programCurrentTime, duration || programCurrentTime || 0));
+function formatTime(sec) {
+  if (!Number.isFinite(sec) || sec < 0) sec = 0;
+  const total = Math.floor(sec);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function updateDisplayUI() {
+  if (!displayScrubber || !displayTimeLabel) return;
+
+  const duration = displayDuration > 0 ? displayDuration : 0;
+  const current = Math.max(0, Math.min(displayCurrentTime, duration || displayCurrentTime || 0));
   const ratio = duration > 0 ? current / duration : 0;
+  const percent = Math.max(0, Math.min(ratio, 1)) * 100;
 
-  const clamped = Math.max(0, Math.min(ratio, 1));
-  const percent = clamped * 100;
-
-  progressFill.style.width = `${percent}%`;
-  progressHandle.style.left = `${percent}%`;
+  displayScrubber.value = String(percent);
+  displayTimeLabel.textContent = `${formatTime(current)} / ${formatTime(duration)}`;
 }
 
-function timeFromProgressEvent(evt) {
-  if (!progressTrack || programDuration <= 0) return 0;
-  const rect = progressTrack.getBoundingClientRect();
-  if (!rect.width) return 0;
-  const x = Math.max(rect.left, Math.min(evt.clientX, rect.right));
-  const ratio = (x - rect.left) / rect.width;
-  return Math.max(0, Math.min(programDuration, ratio * programDuration));
-}
+function setupDisplayScrubber() {
+  if (!displayScrubber) return;
 
-if (progressTrack) {
-  const handlePointerMove = (evt) => {
-    if (!isScrubbingProgram) return;
-    const t = timeFromProgressEvent(evt);
-    programCurrentTime = t;
-    updateProgramProgressUI();
+  const updateFromPercent = () => {
+    const percent = parseFloat(displayScrubber.value) || 0;
+    const ratio = Math.max(0, Math.min(percent / 100, 1));
+    if (displayDuration > 0) {
+      displayCurrentTime = displayDuration * ratio;
+    } else {
+      displayCurrentTime = 0;
+    }
+    updateDisplayUI();
   };
 
-  const handlePointerUp = (evt) => {
-    if (!isScrubbingProgram) return;
-    const t = timeFromProgressEvent(evt);
-    programCurrentTime = t;
-    updateProgramProgressUI();
-    isScrubbingProgram = false;
+  displayScrubber.addEventListener('input', () => {
+    isDisplayScrubbing = true;
+    updateFromPercent();
+  });
 
-    document.removeEventListener('pointermove', handlePointerMove);
-    document.removeEventListener('pointerup', handlePointerUp);
+  displayScrubber.addEventListener('change', () => {
+    updateFromPercent();
+    isDisplayScrubbing = false;
 
-    window.presenterAPI?.send?.('display:seek', { time: t });
-  };
-
-  progressTrack.addEventListener('pointerdown', (evt) => {
-    if (programDuration <= 0) return;
-    isScrubbingProgram = true;
-    progressTrack.setPointerCapture?.(evt.pointerId);
-    const t = timeFromProgressEvent(evt);
-    programCurrentTime = t;
-    updateProgramProgressUI();
-
-    document.addEventListener('pointermove', handlePointerMove);
-    document.addEventListener('pointerup', handlePointerUp);
+    window.presenterAPI?.send?.('display:seek', { time: displayCurrentTime });
   });
 }
 
@@ -950,10 +941,16 @@ if (nextUpArea) {
 
 window.presenterAPI?.onProgramEvent?.('display:playback-progress', (payload) => {
   if (!payload || typeof payload.currentTime !== 'number' || typeof payload.duration !== 'number') return;
-  programDuration = Math.max(0, payload.duration);
-  if (!isScrubbingProgram) {
-    programCurrentTime = Math.max(0, payload.currentTime);
-    updateProgramProgressUI();
+
+  const dur = Math.max(0, payload.duration);
+
+  if (dur > 0) {
+    displayDuration = dur;
+  }
+
+  if (!isDisplayScrubbing) {
+    displayCurrentTime = Math.max(0, payload.currentTime);
+    updateDisplayUI();
   }
 });
 
@@ -972,9 +969,9 @@ window.presenterAPI?.onProgramEvent?.('display:ended', () => {
     console.log('CONTROL: No Preview or Next Up — show fallback background');
   }
 
-  programDuration = 0;
-  programCurrentTime = 0;
-  updateProgramProgressUI();
+  displayCurrentTime = 0;
+  displayDuration = 0;
+  updateDisplayUI();
 });
 
 renderNextUp(null);

--- a/ui/control.js
+++ b/ui/control.js
@@ -16,6 +16,11 @@ const previewArea = document.getElementById('previewArea');
 const nextUpArea = document.getElementById('nextUpArea');
 const leftPanel = document.querySelector('.left-panel');
 
+const programTimeLabel = document.getElementById('programTimeLabel');
+const programProgressTrack = document.getElementById('programProgressTrack');
+const programProgressFill = document.getElementById('programProgressFill');
+const programProgressHandle = document.getElementById('programProgressHandle');
+
 const loggerBody = document.getElementById('loggerBody');
 const loggerCard = document.getElementById('loggerCard');
 const loggerCountEl = document.getElementById('loggerCount');
@@ -38,6 +43,10 @@ const logBuffer = [];
 const selectedMediaIds = new Set();
 
 let draggingId = null;
+
+let programDuration = 0;
+let programCurrentTime = 0;
+let isProgramScrubbing = false;
 
 function indexById(arr, id) {
   return arr.findIndex((m) => m.id === id);
@@ -84,6 +93,7 @@ btnRepeatToggle.onclick = () => {
 
 updatePlayToggleUI(false);
 updateRepeatButton();
+updateProgramProgressUI();
 
 function fileUrl(p) {
   try {
@@ -111,6 +121,76 @@ function tsString(ts) {
   const d = new Date(ts);
   const ms = d.getMilliseconds().toString().padStart(3, '0');
   return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}.${ms}`;
+}
+
+function formatTimeSeconds(sec) {
+  if (!Number.isFinite(sec) || sec < 0) sec = 0;
+  const total = Math.floor(sec);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function updateProgramProgressUI() {
+  if (!programProgressTrack || !programProgressFill || !programProgressHandle) return;
+  const duration = programDuration > 0 ? programDuration : 0;
+  const current = Math.max(0, Math.min(programCurrentTime, duration || programCurrentTime || 0));
+  const ratio = duration > 0 ? current / duration : 0;
+
+  const clamped = Math.max(0, Math.min(ratio, 1));
+  const percent = clamped * 100;
+
+  programProgressFill.style.width = `${percent}%`;
+  programProgressHandle.style.left = `${percent}%`;
+
+  if (programTimeLabel) {
+    const left = formatTimeSeconds(current);
+    const right = formatTimeSeconds(duration);
+    programTimeLabel.textContent = `${left} / ${right}`;
+  }
+}
+
+function getProgramTimeFromEvent(evt) {
+  if (!programProgressTrack || programDuration <= 0) return 0;
+  const rect = programProgressTrack.getBoundingClientRect();
+  if (!rect.width) return 0;
+  const x = Math.max(rect.left, Math.min(evt.clientX, rect.right));
+  const ratio = (x - rect.left) / rect.width;
+  return Math.max(0, Math.min(programDuration, ratio * programDuration));
+}
+
+if (programProgressTrack) {
+  const handlePointerMove = (evt) => {
+    if (!isProgramScrubbing) return;
+    const t = getProgramTimeFromEvent(evt);
+    programCurrentTime = t;
+    updateProgramProgressUI();
+  };
+
+  const handlePointerUp = (evt) => {
+    if (!isProgramScrubbing) return;
+    const t = getProgramTimeFromEvent(evt);
+    programCurrentTime = t;
+    updateProgramProgressUI();
+    isProgramScrubbing = false;
+
+    document.removeEventListener('pointermove', handlePointerMove);
+    document.removeEventListener('pointerup', handlePointerUp);
+
+    window.presenterAPI?.send?.('display:seek', { time: t });
+  };
+
+  programProgressTrack.addEventListener('pointerdown', (evt) => {
+    if (programDuration <= 0) return;
+    isProgramScrubbing = true;
+    programProgressTrack.setPointerCapture?.(evt.pointerId);
+    const t = getProgramTimeFromEvent(evt);
+    programCurrentTime = t;
+    updateProgramProgressUI();
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
+  });
 }
 
 function appendLog(entry) {
@@ -883,6 +963,19 @@ if (nextUpArea) {
   });
 }
 
+window.presenterAPI?.onProgramEvent?.('display:playback-progress', (payload) => {
+  if (!payload || typeof payload.currentTime !== 'number' || typeof payload.duration !== 'number') return;
+  const dur = Math.max(0, payload.duration);
+  if (dur > 0 || payload.duration === 0) {
+    programDuration = dur;
+  }
+
+  if (!isProgramScrubbing) {
+    programCurrentTime = Math.max(0, payload.currentTime);
+    updateProgramProgressUI();
+  }
+});
+
 window.presenterAPI?.onProgramEvent?.('display:ended', () => {
   console.log('CONTROL: Display finished playback, advancing media');
   const pushed = pushAtomicFromPreviewAndBackfill();
@@ -897,6 +990,10 @@ window.presenterAPI?.onProgramEvent?.('display:ended', () => {
   if (!previewId && !nextUpId) {
     console.log('CONTROL: No Preview or Next Up — show fallback background');
   }
+
+  programDuration = 0;
+  programCurrentTime = 0;
+  updateProgramProgressUI();
 });
 
 renderNextUp(null);

--- a/ui/display.js
+++ b/ui/display.js
@@ -81,18 +81,25 @@ window.presenterAPI.send('display:get-background');
   });
 })();
 
-function sendPlaybackProgressFrom(el) {
+function sendPlaybackProgressFrom(el, from = 'unknown') {
   if (!el) return;
+  const active = getActiveProgramElement();
+
+  // FIX: only report progress for the active program element so stale 0,0 events
+  // from cleared layers don't override scrubbing state on the control side.
+  if (active && el !== active) return;
+
   const currentTime = Number.isFinite(el.currentTime) ? el.currentTime : 0;
   const duration = Number.isFinite(el.duration) ? el.duration : 0;
+  console.log('[DISPLAY] playback-progress', { from, currentTime, duration });
   window.presenterAPI.send('display:playback-progress', { currentTime, duration });
 }
 
 [videoA, videoB, audioEl].forEach((el) => {
   if (!el) return;
-  el.addEventListener('timeupdate', () => sendPlaybackProgressFrom(el));
-  el.addEventListener('loadedmetadata', () => sendPlaybackProgressFrom(el));
-  el.addEventListener('durationchange', () => sendPlaybackProgressFrom(el));
+  el.addEventListener('timeupdate', () => sendPlaybackProgressFrom(el, 'timeupdate'));
+  el.addEventListener('loadedmetadata', () => sendPlaybackProgressFrom(el, 'loadedmetadata'));
+  el.addEventListener('durationchange', () => sendPlaybackProgressFrom(el, 'durationchange'));
 });
 
 function getLayerElements(key) {
@@ -325,6 +332,7 @@ function showItem(item) {
   resetSwapTimer();
 
   if (!item) {
+    console.log('[DISPLAY] resetting media or progress here', { reason: 'no-item' });
     window.presenterAPI.send('display:playback-progress', { currentTime: 0, duration: 0 });
     hideAll();
     if (!isBlanked && backgroundImagePath) {
@@ -420,6 +428,7 @@ function showItem(item) {
 
 function playCurrent() {
   const { video } = getActiveLayer();
+  console.log('[DISPLAY] playCurrent called', { currentType });
   if (currentType === 'video' && video.classList.contains('show')) {
     video.play().catch((err) => {
       notifyError('Unable to play video.', err);
@@ -445,6 +454,7 @@ function onEnded(ev) {
     try {
       const el = ev?.target || (currentType === 'video' ? getActiveLayer().video : audioEl);
       if (el) {
+        console.log('[DISPLAY] resetting media or progress here', { reason: 'repeat-ended' });
         el.currentTime = 0;
         el.play().catch(() => {});
       }
@@ -522,6 +532,9 @@ window.presenterAPI.onProgramEvent('display:seek', (payload) => {
   }
 
   const target = Math.max(0, payload.time);
+
+  // display:seek is handled only in this block on the Display window.
+  console.log('[DISPLAY] display:seek received time', target);
 
   let el = null;
 

--- a/ui/display.js
+++ b/ui/display.js
@@ -508,18 +508,18 @@ window.presenterAPI.onProgramEvent('display:set-background', (absPath) => {
 window.presenterAPI.onProgramEvent('display:seek', (payload) => {
   if (!payload || typeof payload.time !== 'number' || !Number.isFinite(payload.time)) return;
   const target = Math.max(0, payload.time);
+
+  let el = null;
+
   if (currentType === 'video') {
-    const { video } = getActiveLayer();
-    if (video && Number.isFinite(video.duration) && video.duration > 0) {
-      video.currentTime = Math.min(target, video.duration);
-    } else if (video) {
-      video.currentTime = target;
-    }
+    const active = getActiveLayer && getActiveLayer();
+    el = active && active.video ? active.video : null;
   } else if (currentType === 'audio') {
-    if (audioEl && Number.isFinite(audioEl.duration) && audioEl.duration > 0) {
-      audioEl.currentTime = Math.min(target, audioEl.duration);
-    } else if (audioEl) {
-      audioEl.currentTime = target;
-    }
+    el = audioEl;
   }
+
+  if (!el) return;
+
+  const dur = Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null;
+  el.currentTime = dur ? Math.min(target, dur) : target;
 });

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -70,6 +70,8 @@ button:active {
 }
 .preview-card {
   min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .card > header {
@@ -106,6 +108,46 @@ button:active {
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 0;
+}
+
+.program-progress-wrapper {
+  padding: 6px 10px;
+  border-top: 1px solid #1e1e1e;
+  border-bottom: 1px solid #1e1e1e;
+  background: #0b0b0b;
+  flex: 0 0 auto;
+}
+
+.program-progress-track {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: #222;
+  cursor: pointer;
+}
+
+.program-progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  background: #3a86ff;
+}
+
+.program-progress-handle {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #f5f5f5;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.preview-card .preview-stage {
+  flex: 1 1 auto;
   min-height: 0;
 }
 

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -119,6 +119,10 @@ button:active {
   flex: 0 0 auto;
 }
 
+.program-progress-wrapper input[type="range"] {
+  width: 100%;
+}
+
 .program-progress-track {
   position: relative;
   height: 6px;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -70,6 +70,8 @@ button:active {
 }
 .preview-card {
   min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .card > header {
@@ -106,6 +108,61 @@ button:active {
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 0;
+}
+
+.program-card {
+  min-height: auto;
+}
+
+.program-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.program-time-label {
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: #bbb;
+}
+
+.program-progress-wrapper {
+  padding: 10px 12px 12px;
+  background: #070707;
+}
+
+.program-progress-track {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: #2a2a2a;
+  cursor: pointer;
+}
+
+.program-progress-fill {
+  position: absolute;
+  height: 100%;
+  left: 0;
+  top: 0;
+  width: 0%;
+  border-radius: inherit;
+  background: #cccccc;
+}
+
+.program-progress-handle {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #f5f5f5;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.preview-card .preview-stage {
+  flex: 1 1 auto;
   min-height: 0;
 }
 

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -51,7 +51,7 @@ button:active {
 
 .right-panel {
   display: grid;
-  grid-template-rows: 1fr 0.8fr;
+  grid-template-rows: auto 1fr 0.8fr;
   gap: 16px;
   min-height: 0;
 }
@@ -70,6 +70,8 @@ button:active {
 }
 .preview-card {
   min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .card > header {
@@ -106,6 +108,80 @@ button:active {
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 0;
+}
+
+
+.display-card {
+  padding: 6px 10px 8px;
+  min-height: 0;
+}
+
+.display-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.display-title {
+  font-weight: 600;
+}
+
+.display-time {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.display-progress-row {
+  display: flex;
+  align-items: center;
+}
+
+.display-scrubber {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: #d0d0d0;
+  outline: none;
+  margin: 0;
+}
+
+.display-scrubber::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: #d0d0d0;
+}
+
+.display-scrubber::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: #d0d0d0;
+}
+
+.display-scrubber::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 1px solid #999;
+  margin-top: -3px;
+}
+
+.display-scrubber::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 1px solid #999;
+}
+
+.preview-card .preview-stage {
+  flex: 1 1 auto;
   min-height: 0;
 }
 


### PR DESCRIPTION
## Summary
- track the current program media element explicitly and clear it when items are hidden or unsupported
- report progress and seek using the tracked program element to avoid stale layer updates
- streamline seek handling and ended logging to keep scrubbing from snapping back to zero

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f711a1df88324abcd8665c2feb575)