### PR TITLE
Wire display playback progress and seeking

### DIFF
--- a/main.js
+++ b/main.js
@@ -283,6 +283,11 @@ ipcMain.on('display:pause', () => {
 ipcMain.on('display:play', () => {
   if (displayWin && !displayWin.isDestroyed()) displayWin.webContents.send('display:play');
 });
+ipcMain.on('display:seek', (_evt, payload) => {
+  if (displayWin && !displayWin.isDestroyed()) {
+    displayWin.webContents.send('display:seek', payload);
+  }
+});
 ipcMain.on('display:ended', () => {
   if (controlWin && !controlWin.isDestroyed()) controlWin.webContents.send('display:ended');
   logMain('INFO', 'Display reported playback ended');
@@ -290,4 +295,9 @@ ipcMain.on('display:ended', () => {
 ipcMain.on('display:error', (_evt, payload) => {
   if (controlWin && !controlWin.isDestroyed()) controlWin.webContents.send('display:error', payload);
   logMain('ERROR', 'Display error forwarded to control', payload);
+});
+ipcMain.on('display:playback-progress', (_evt, payload) => {
+  if (controlWin && !controlWin.isDestroyed()) {
+    controlWin.webContents.send('display:playback-progress', payload);
+  }
 });


### PR DESCRIPTION
## Summary
- send display playback progress updates from active media elements and reset progress when clearing content
- forward playback progress to the Control window and relay seek requests back to Display
- handle seek events in Display, keeping current media element in sync with the Control scrubber

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f9cbe59a88324b0215086f4a31fe3)