### PR TITLE
Fix display scrubber snapback after seeking

### DIFF
--- a/ui/control.js
+++ b/ui/control.js
@@ -800,8 +800,6 @@ function setupDisplayScrubber() {
     const ratio = Math.max(0, Math.min(percent / 100, 1));
     if (displayDuration > 0) {
       displayCurrentTime = displayDuration * ratio;
-    } else {
-      displayCurrentTime = 0;
     }
     updateDisplayUI();
   };
@@ -952,6 +950,8 @@ window.presenterAPI?.onProgramEvent?.('display:playback-progress', (payload) => 
     displayCurrentTime = Math.max(0, payload.currentTime);
     updateDisplayUI();
   }
+
+  console.log('[CONTROL] playback-progress', payload, 'scrubbing?', isDisplayScrubbing);
 });
 
 window.presenterAPI?.onProgramEvent?.('display:ended', () => {

--- a/ui/display.js
+++ b/ui/display.js
@@ -38,6 +38,7 @@ function sendPlaybackProgressFrom(el, from = 'unknown') {
   const currentTime = Number.isFinite(el.currentTime) ? el.currentTime : 0;
   const duration = Number.isFinite(el.duration) ? el.duration : 0;
 
+  console.log('[DISPLAY] playback-progress from', from, 'currentTime', currentTime, 'duration', duration, 'active?', el === currentMediaEl);
   window.presenterAPI.send('display:playback-progress', { currentTime, duration });
 }
 
@@ -249,6 +250,7 @@ function hideAll() {
   currentType = null;
   currentMediaEl = null;
 
+  console.log('[DISPLAY] hideAll – resetting progress to 0');
   window.presenterAPI.send('display:playback-progress', { currentTime: 0, duration: 0 });
 }
 
@@ -521,6 +523,7 @@ window.presenterAPI.onProgramEvent('display:seek', (payload) => {
     return;
   }
 
+  console.log('[DISPLAY] display:seek payload', payload, 'currentMediaEl?', !!currentMediaEl);
   const target = Math.max(0, payload.time);
   const el = currentMediaEl;
 


### PR DESCRIPTION
## Summary
- prevent control-side scrubber from resetting intended seek time when duration is unknown
- add logging to control and display to trace playback progress and seek handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f9ea3cd908324a0e37d3bb1a5fa9f)