### PR TITLE
Restore Explorer file drop in Control window

### DIFF
--- a/ui/control.js
+++ b/ui/control.js
@@ -841,6 +841,46 @@ function setupDropTarget(target, onDrop) {
   });
 }
 
+function setupExplorerFileDrop() {
+  const root = document.body;
+  if (!root) return;
+
+  const hasFiles = (dataTransfer) => Array.from(dataTransfer?.types || []).includes('Files');
+
+  const handleDragOver = (e) => {
+    if (e.defaultPrevented || !hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = 'copy';
+    }
+    console.log('[CONTROL-DROP] dragover', e.dataTransfer?.types);
+  };
+
+  const handleDrop = (e) => {
+    if (e.defaultPrevented || !hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+
+    const files = Array.from(e.dataTransfer?.files || []);
+    if (!files.length) {
+      console.log('[CONTROL-DROP] Drop event had no files');
+      return;
+    }
+
+    const paths = files.map((file) => file.path).filter((p) => typeof p === 'string' && p.length > 0);
+    console.log('[CONTROL-DROP] drop paths', paths);
+
+    if (!paths.length) {
+      console.log('[CONTROL-DROP] Drop event had files but no usable paths');
+      return;
+    }
+
+    addPathsToMedia(paths);
+  };
+
+  root.addEventListener('dragover', handleDragOver);
+  root.addEventListener('drop', handleDrop);
+}
+
 setupDropTarget(grid, (paths) => {
   addPathsToMedia(paths);
 });
@@ -848,6 +888,8 @@ setupDropTarget(grid, (paths) => {
 setupDropTarget(leftPanel, (paths) => {
   addPathsToMedia(paths);
 });
+
+setupExplorerFileDrop();
 
 setupDisplayScrubber();
 updateDisplayUI();


### PR DESCRIPTION
## Summary
- add a Control window-wide drag/drop handler to accept OS file drops and feed them into existing media add logic
- log Control drop events to help verify explorer drag/drop flow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309f6228608324a65f6236df56d54e)