### PR TITLE
Disable automatic stage/preview on media grid clicks

### DIFF
--- a/ui/control.js
+++ b/ui/control.js
@@ -1,3 +1,6 @@
+// CHANGES:
+// - Disabled media grid click/dblclick actions that auto-loaded Preview/Program.
+// - Kept drag-and-drop and button-based controls unchanged.
 const btnAdd = document.getElementById('btnAdd');
 const btnPush = document.getElementById('btnPush');
 const btnClearPreview = document.getElementById('btnClearPreview');
@@ -409,14 +412,13 @@ function buildThumb(item, { interactive = true } = {}) {
       } else {
         container.classList.remove('selected');
       }
-
-      stageNext(item.id);
+      // Click-to-stage / double-click-to-preview disabled by request
     });
 
     container.addEventListener('dblclick', () => {
       selectedMediaIds.clear();
       selectedMediaIds.add(item.id);
-      previewItem(item.id);
+      // Click-to-stage / double-click-to-preview disabled by request
     });
 
     container.addEventListener('dragstart', (e) => {


### PR DESCRIPTION
## Summary
- add change log comment describing disabled auto-preview/program actions
- prevent media grid click and double-click handlers from staging or previewing items automatically while retaining selection and drag support

## Testing
- npm start (fails: missing system library libatk-1.0.so.0 in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ddd324dc83249694d2b420f6cadd)